### PR TITLE
Debug: Missing File Extension Crash

### DIFF
--- a/changelist_sort/sorting/module_sort.py
+++ b/changelist_sort/sorting/module_sort.py
@@ -82,6 +82,10 @@ def is_sorted_by_module(
         if cl_key.key.startswith(get_module_keys(ModuleType.ROOT)):
             return True
         # File Extension Checks
+        if file.file_ext is None:
+            # No FileExt Should Sort into Root CL
+            return False
+        # Check for Gradle FileExt
         return file.file_ext.endswith(
             file_sort._GRADLE_FILE_SUFFIXES
         ) and cl_key.key.startswith(

--- a/test/sorting/test_module_sort.py
+++ b/test/sorting/test_module_sort.py
@@ -194,3 +194,9 @@ def test_is_sorted_by_module_github_cl_dependabot_returns_true():
     assert is_sorted_by_module(
         cl.list_key, data_provider.get_change_data('/.github/dependabot.yml')
     )
+
+def test_is_sorted_by_module_root_cl_gradlew_no_file_ext_returns_true():
+    cl = data_provider.get_root_changelist()
+    assert is_sorted_by_module(
+        cl.list_key, data_provider.get_change_data('/gradlew')
+    )

--- a/test/sorting/test_module_sort.py
+++ b/test/sorting/test_module_sort.py
@@ -203,6 +203,6 @@ def test_is_sorted_by_module_root_cl_gradlew_no_file_ext_returns_true():
 
 def test_is_sorted_by_module_build_updates_cl_gradlew_no_file_ext_returns_false():
     cl = data_provider.get_build_updates_changelist()
-    assert is_sorted_by_module(
+    assert not is_sorted_by_module(
         cl.list_key, data_provider.get_change_data('/gradlew')
     )

--- a/test/sorting/test_module_sort.py
+++ b/test/sorting/test_module_sort.py
@@ -200,3 +200,9 @@ def test_is_sorted_by_module_root_cl_gradlew_no_file_ext_returns_true():
     assert is_sorted_by_module(
         cl.list_key, data_provider.get_change_data('/gradlew')
     )
+
+def test_is_sorted_by_module_build_updates_cl_gradlew_no_file_ext_returns_false():
+    cl = data_provider.get_build_updates_changelist()
+    assert is_sorted_by_module(
+        cl.list_key, data_provider.get_change_data('/gradlew')
+    )

--- a/test/test_change_data.py
+++ b/test/test_change_data.py
@@ -109,3 +109,8 @@ def test_file_ext_hidden_file_no_ext_returns_none():
 def test_file_ext_gradle_kts_returns_ext():
     cd = data_provider.get_change_data('/module/build.gradle.kts')
     assert 'gradle.kts' == cd.file_ext
+
+
+def test_file_ext_gradlew_executable_returns_none():
+    cd = data_provider.get_change_data('/gradlew')
+    assert cd.file_ext is None


### PR DESCRIPTION
When a file in the root directory has no file extension, and is not in the Root Changelist the program crashes.

There is a code path for Root ModuleType files where if the File is not in the Root Changelist, it will check the file extension against common gradle extensions. This is to move Gradle files into the Gradle Changelists.