### PR TITLE
Remove Print Statement For Sorting Result

### DIFF
--- a/changelist_sort/sorting/__init__.py
+++ b/changelist_sort/sorting/__init__.py
@@ -36,11 +36,10 @@ def sort(
         )
     # This Callable depends on SortMode.
     #  It determines map keys, and executes map insertions.
-    sort_result_string = _process_file_sort_results(list(map(
+    map(
         _create_sorting_callable(cl_map, sort_mode),
         unsorted_files
-    )))
-    print(sort_result_string)
+    )
     return cl_map.get_lists()
 
 
@@ -94,11 +93,3 @@ def _handle_map_insertion_error(
     else:
         exit(f"Failed to Insert Changelist(name={failure_cl.name}) for unknown reason (neither key nor id conflict has occurred).")
 
-
-def _process_file_sort_results(results: list[bool]) -> str:
-    """
-    Process and Format a string to print.
-    """
-    correct = sum(results)
-    total = len(results)
-    return f"Sorted {correct} of {total} unsorted files."


### PR DESCRIPTION
## The Premise
A CLI program of a good quality does not print information that you didn't ask for.

## Current Status
Currently, the program prints a **Success Message** after a sorting operation has completed. This message was added as a quick feedback during experimentation with early sorting method implementations. It is no longer necessary, as effective testing patterns have been established for existing algorithms.

## Continuous Improvement
In the pursuit of maximum productivity and efficiency, the `changelist-sort` program is being utilized in developer workflow scripts. In this context, the **Success Message** is simply noise added to a successful script log.

## Resolution
To improve the productivity and efficiency of developers using `changeist-sort` in workflow scripts, the success message will no longer be printed.

### Future Considerations
This **Success Message** may be added back as an opt-in option in the future.