### PR TITLE
Fix Workflows CodeQL Permissions Warnings

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -1,8 +1,6 @@
 # This workflow installs Python dependencies, runs unit tests and uploads coverage reports.
 # Info: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python unit test and coverage report
-
 on:
   push:
     branches: [ main ]
@@ -18,8 +16,14 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [ '3.10', '3.11', '3.12', '3.13' ]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+        
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,5 @@
 ## Code Linting
-
 name: Code Linting
-
 on:
   pull_request:
     branches: [main]
@@ -9,8 +7,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/merge_test.yml
+++ b/.github/workflows/merge_test.yml
@@ -1,8 +1,6 @@
 # This workflow installs Python and test dependencies, runs unit tests and coverage reports.
 # Info: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Run Faster Tests on Pull Requests into Release
-
 on:
   pull_request:
     branches: [ release-* ]
@@ -15,8 +13,14 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.13' ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -26,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest==8.3.3 pytest-cov==5.0.0
+          pip install pytest==8.3.5 pytest-cov==6.1.1
 
       - name: Run unit tests
         run: pytest test/ --cov=changelist_sort --cov-report=html


### PR DESCRIPTION
CodeQL: actions/missing-workflow-permissions

If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.